### PR TITLE
Changes to tests

### DIFF
--- a/src/FedoraApi.php
+++ b/src/FedoraApi.php
@@ -255,12 +255,14 @@ class FedoraApi implements IFedoraApi
         $headers['Content-Type'] = 'text/turtle';
         $headers['digest'] = 'sha1=' . $checksum_value;
 
+        $options['headers'] = $headers;
+        $options['body'] = $turtle;
+
         // Save it.
         return $this->client->request(
             'POST',
-            $turtle,
             $uri,
-            $headers
+            $options
         );
     }
 
@@ -269,14 +271,16 @@ class FedoraApi implements IFedoraApi
      *
      * @param ResponseInterface   $request    Response received
      *
-     * @return EasyRdf_Resource
+     * @return \EasyRdf_Graph
      */
     public function getGraph(ResponseInterface $response)
     {
         // Extract rdf as response body and return Easy_RDF Graph object.
-        $rdf = $response->getBody();
+        $rdf = $response->getBody()->getContents();
         $graph = new \EasyRdf_Graph();
-        $graph->parse($rdf, 'jsonld');
+        if (!empty($rdf)) {
+            $graph->parse($rdf, 'jsonld');
+        }
         return $graph;
     }
 }

--- a/test/CreateResourceTest.php
+++ b/test/CreateResourceTest.php
@@ -26,12 +26,15 @@ class CreateResourceTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->createResource("");
-        $this->assertSame($result, "SOME URI");
+        $this->assertEquals($result->getHeaderLine("Location"), "SOME URI");
+        $this->assertEquals(201, $result->getStatusCode(), "Expected a 201 response.");
     }
 
     /**
      * @covers  Islandora\Chullo\FedoraApi::createResource
      * @uses    GuzzleHttp\Client
+     *
+     * TODO: Is this useful anymore?
      */
     public function testReturnsNullOtherwise()
     {
@@ -46,10 +49,10 @@ class CreateResourceTest extends \PHPUnit_Framework_TestCase
 
         // 404
         $result = $api->createResource("");
-        $this->assertNull($result);
+        $this->assertEquals(404, $result->getStatusCode());
 
         // 409
         $result = $api->createResource("");
-        $this->assertNull($result);
+        $this->assertEquals(409, $result->getStatusCode());
     }
 }

--- a/test/DeleteResourceTest.php
+++ b/test/DeleteResourceTest.php
@@ -26,12 +26,14 @@ class DeleteResourceTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->deleteResource("");
-        $this->assertTrue($result);
+        $this->assertEquals(204, $result->getStatusCode());
     }
 
     /**
      * @covers  Islandora\Chullo\FedoraApi::deleteResource
      * @uses    GuzzleHttp\Client
+     *
+     * TODO: Is this useful anymore?
      */
     public function testReturnsFalseOtherwise()
     {
@@ -44,6 +46,6 @@ class DeleteResourceTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->deleteResource("");
-        $this->assertFalse($result);
+        $this->assertEquals(404, $result->getStatusCode());
     }
 }

--- a/test/GetGraphTest.php
+++ b/test/GetGraphTest.php
@@ -77,17 +77,22 @@ EOD;
         $guzzle = new Client(['handler' => $handler]);
         $api = new FedoraApi($guzzle);
 
-        $graph = $api->getGraph();
+        $result = $api->getResource("");
+
+        $graph = $api->getGraph($result);
         $title = (string)$graph->get(
             "http://127.0.0.1:8080/fcrepo/rest/4d/8b/2d/8e/4d8b2d8e-d063-4c9f-aac9-6b285b193ed6",
             "dc:title"
         );
-        $this->assertSame($title, "My Sweet Title");
+
+        $this->assertSame("My Sweet Title", $title);
     }
 
     /**
      * @covers  Islandora\Chullo\FedoraApi::getGraph
      * @uses    GuzzleHttp\Client
+     *
+     * TODO: Is this useful anymore?
      */
     public function testReturnsNullOtherwise()
     {
@@ -101,11 +106,11 @@ EOD;
         $api = new FedoraApi($guzzle);
 
         // 304
-        $result = $api->getGraph("");
-        $this->assertNull($result);
+        $result = $api->getGraph($api->getResource(""));
+        $this->assertEquals(new \EasyRdf_Graph(), $result);
 
         //404
-        $result = $api->getGraph("");
-        $this->assertNull($result);
+        $result = $api->getGraph($api->getResource(""));
+        $this->assertEquals(new \EasyRdf_Graph(), $result);
     }
 }

--- a/test/GetResourceHeadersTest.php
+++ b/test/GetResourceHeadersTest.php
@@ -17,14 +17,22 @@ class GetResourceHeadersTest extends \PHPUnit_Framework_TestCase
      */
     public function testReturnsHeadersOn200()
     {
+
+        $headers = [
+            'Status' => '200 OK',
+            'ETag' => "bbdd92e395800153a686773f773bcad80a51f47b",
+            'Last-Modified' => 'Wed, 28 May 2014 18:31:36 GMT',
+            'Link' => '<http://www.w3.org/ns/ldp#Resource>;rel="type"',
+            'Link' => '<http://www.w3.org/ns/ldp#Container>;rel="type"',
+            'Link' => '<http://www.w3.org/ns/ldp#BasicContainer>;rel="type"',
+            'Accept-Patch' => 'application/sparql-update',
+            'Accept-Post' => 'text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,' .
+                'multipart/form-data,application/sparql-update',
+            'Allow' => 'MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS',
+        ];
+
         $mock = new MockHandler([
-          new Response(200, ['Status: 200 OK', 'ETag: "bbdd92e395800153a686773f773bcad80a51f47b"',
-          'Last-Modified: Wed, 28 May 2014 18:31:36 GMT', 'Last-Modified: Thu, 20 Nov 2014 15:44:32 GMT',
-          'Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"',
-          'Link: <http://www.w3.org/ns/ldp#Container>;rel="type"',
-          'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"', 'Accept-Patch: application/sparql-update',
-          'Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,multipart/form-data,'
-          . 'application/sparql-update', 'Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS']),
+          new Response(200, $headers)
         ]);
 
         $handler = HandlerStack::create($mock);
@@ -32,19 +40,17 @@ class GetResourceHeadersTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->getResourceHeaders("");
-        $this->assertSame((array)$result, [['Status: 200 OK'], ['ETag: "bbdd92e395800153a686773f773bcad80a51f47b"'],
-          ['Last-Modified: Wed, 28 May 2014 18:31:36 GMT'], ['Last-Modified: Thu, 20 Nov 2014 15:44:32 GMT'],
-          ['Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"'],
-          ['Link: <http://www.w3.org/ns/ldp#Container>;rel="type"'],
-          ['Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"'], ['Accept-Patch: application/sparql-update'],
-          ['Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,'
-          . 'multipart/form-data,application/sparql-update'],
-          ['Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS']]);
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertTrue($result->hasHeader("etag"));
+        $this->assertEquals("bbdd92e395800153a686773f773bcad80a51f47b", $result->getHeaderLine("ETag"));
     }
 
     /**
      * @covers  Islandora\Chullo\FedoraApi::getResourceHeaders
      * @uses    GuzzleHttp\Client
+     *
+     * TODO: Is this useful anymore?
      */
     public function testReturnsNullOtherwise()
     {
@@ -57,6 +63,6 @@ class GetResourceHeadersTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->getResourceHeaders("");
-        $this->assertNull($result);
+        $this->assertEquals(404, $result->getStatusCode());
     }
 }

--- a/test/GetResourceOptionsTest.php
+++ b/test/GetResourceOptionsTest.php
@@ -17,11 +17,15 @@ class GetResourceOptionsTest extends \PHPUnit_Framework_TestCase
      */
     public function testReturnsHeadersOn200()
     {
+        $headers = [
+            'Status' => '200 OK',
+            'Accept-Patch' => 'application/sparql-update',
+            'Allow' => 'MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS',
+            'Accept-Post' => 'text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,' .
+                'application/n-triples,multipart/form-data,application/sparql-update',
+        ];
         $mock = new MockHandler([
-          new Response(200, ['Status: 200 OK', 'Accept-Patch: application/sparql-update',
-          'Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS',
-          'Accept-Post: text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,
-          multipart/form-data,application/sparql-update']),
+          new Response(200, $headers),
         ]);
 
         $handler = HandlerStack::create($mock);
@@ -29,9 +33,9 @@ class GetResourceOptionsTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->getResourceOptions("");
-        $this->assertSame((array)$result, [['Status: 200 OK'], ['Accept-Patch: application/sparql-update'],
-          ['Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS'],
-          ['Accept-Post: text/turtle,text/rdf+n3,application/n3,text/n3,application/rdf+xml,application/n-triples,
-          multipart/form-data,application/sparql-update']]);
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals($headers['Allow'], $result->getHeaderLine('allow'));
+        $this->assertEquals($headers['Accept-Patch'], $result->getHeaderLine('accept-patch'));
+        $this->assertEquals($headers['Accept-Post'], $result->getHeaderLine('accept-post'));
     }
 }

--- a/test/GetResourceTest.php
+++ b/test/GetResourceTest.php
@@ -32,6 +32,8 @@ class GetResourceTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers  Islandora\Chullo\FedoraApi::getResource
      * @uses    GuzzleHttp\Client
+     *
+     * TODO: Is this useful anymore?
      */
     public function testReturnsNullOtherwise()
     {
@@ -46,10 +48,10 @@ class GetResourceTest extends \PHPUnit_Framework_TestCase
 
         //304
         $result = $api->getResource("");
-        $this->assertNull($result);
+        $this->assertEquals(304, $result->getStatusCode());
 
         //404
         $result = $api->getResource("");
-        $this->assertNull($result);
+        $this->assertEquals(404, $result->getStatusCode());
     }
 }

--- a/test/ModifyResourceTest.php
+++ b/test/ModifyResourceTest.php
@@ -26,12 +26,14 @@ class ModifyResourceTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->modifyResource("");
-        $this->assertTrue($result);
+        $this->assertEquals(204, $result->getStatusCode());
     }
 
     /**
      * @covers  Islandora\Chullo\FedoraApi::modifyResource
      * @uses    GuzzleHttp\Client
+     *
+     * TODO: Is this useful anymore?
      */
     public function testReturnsFalseOtherwise()
     {
@@ -44,9 +46,11 @@ class ModifyResourceTest extends \PHPUnit_Framework_TestCase
         $guzzle = new Client(['handler' => $handler]);
         $api = new FedoraApi($guzzle);
 
-        foreach ($mock as $response) {
-            $result = $api->modifyResource("");
-            $this->assertFalse($result);
-        }
+
+        $result = $api->modifyResource("");
+        $this->assertEquals(412, $result->getStatusCode());
+
+        $result = $api->modifyResource("");
+        $this->assertEquals(404, $result->getStatusCode());
     }
 }

--- a/test/SaveGraphTest.php
+++ b/test/SaveGraphTest.php
@@ -25,15 +25,18 @@ class SaveGraphTest extends \PHPUnit_Framework_TestCase
         $guzzle = new Client(['handler' => $handler]);
         $api = new FedoraApi($guzzle);
 
-        $result = $api->saveGraph("", new \EasyRdf_Graph());
-        $this->assertTrue($result);
+        $result = $api->saveGraph(new \EasyRdf_Graph());
+        $this->assertEquals(204, $result->getStatusCode());
     }
 
     /**
-     * @covers            Islandora\Chullo\Chullo::saveGraph
+     * @covers            Islandora\Chullo\FedoraApi::saveGraph
      * @uses              GuzzleHttp\Client
+     * @expectedException \GuzzleHttp\Exception\ClientException
+     *
+     * TODO: Is this useful anymore?
      */
-    public function testReturnsFalseOtherwise()
+    public function testReturnsExceptionOn412()
     {
         $mock = new MockHandler([
             new Response(412),
@@ -44,9 +47,31 @@ class SaveGraphTest extends \PHPUnit_Framework_TestCase
         $guzzle = new Client(['handler' => $handler]);
         $api = new FedoraApi($guzzle);
 
-        foreach ($mock as $response) {
-            $result = $api->saveGraph("", new \EasyRdf_Graph());
-            $this->assertFalse($result);
-        }
+        $result = $api->saveGraph(new \EasyRdf_Graph());
+        $this->assertEquals(412, $result->getStatusCode());
+
+        $result = $api->saveGraph(new \EasyRdf_Graph());
+        $this->assertEquals(409, $result->getStatusCode());
+    }
+
+    /**
+     * @covers            Islandora\Chullo\FedoraApi::saveGraph
+     * @uses              GuzzleHttp\Client
+     * @expectedException \GuzzleHttp\Exception\ClientException
+     *
+     * TODO: Is this useful anymore?
+     */
+    public function testReturnsExceptionOn409()
+    {
+        $mock = new MockHandler([
+            new Response(409),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Client(['handler' => $handler]);
+        $api = new FedoraApi($guzzle);
+
+        $result = $api->saveGraph(new \EasyRdf_Graph());
+        $this->assertEquals(409, $result->getStatusCode());
     }
 }

--- a/test/SaveResourceTest.php
+++ b/test/SaveResourceTest.php
@@ -26,12 +26,14 @@ class SaveResourceTest extends \PHPUnit_Framework_TestCase
         $api = new FedoraApi($guzzle);
 
         $result = $api->saveResource("");
-        $this->assertTrue($result);
+        $this->assertEquals(204, $result->getStatusCode());
     }
 
     /**
      * @covers  Islandora\Chullo\FedoraApi::saveResource
      * @uses    GuzzleHttp\Client
+     *
+     * TODO: Is this useful anymore?
      */
     public function testReturnsFalseOtherwise()
     {
@@ -44,9 +46,10 @@ class SaveResourceTest extends \PHPUnit_Framework_TestCase
         $guzzle = new Client(['handler' => $handler]);
         $api = new FedoraApi($guzzle);
 
-        foreach ($mock as $response) {
-            $result = $api->createResource("");
-            $this->assertFalse($result);
-        }
+        $result = $api->createResource("");
+        $this->assertEquals(409, $result->getStatusCode());
+
+        $result = $api->createResource("");
+        $this->assertEquals(412, $result->getStatusCode());
     }
 }


### PR DESCRIPTION
There are lots of tests that used to check for Null or False, which now just return the ResponseInterface. Not sure how much we can about a mock test that passes a response back and forth.

I tried to mark them as of questionable value.

@ruebot @dannylamb